### PR TITLE
Add Ratio type which generalizes over Semiring

### DIFF
--- a/docs/Data/Ratio.md
+++ b/docs/Data/Ratio.md
@@ -1,0 +1,28 @@
+## Module Data.Ratio
+
+#### `Ratio`
+
+``` purescript
+data Ratio a
+  = Ratio a a
+```
+
+##### Instances
+``` purescript
+instance semiringRatio :: (Semiring a) => Semiring (Ratio a)
+instance ringRatio :: (Ring a) => Ring (Ratio a)
+```
+
+#### `numerator`
+
+``` purescript
+numerator :: forall a. Ratio a -> a
+```
+
+#### `denominator`
+
+``` purescript
+denominator :: forall a. Ratio a -> a
+```
+
+

--- a/docs/Data/Rational.md
+++ b/docs/Data/Rational.md
@@ -3,12 +3,14 @@
 #### `Rational`
 
 ``` purescript
-data Rational
+newtype Rational
+  = Rational (Ratio Int)
 ```
 
 ##### Instances
 ``` purescript
 instance showRational :: Show Rational
+instance eqRational :: Eq Rational
 instance semiringRational :: Semiring Rational
 instance ringRational :: Ring Rational
 ```
@@ -20,18 +22,6 @@ instance ringRational :: Ring Rational
 ```
 
 _left-associative / precedence 7_
-
-#### `numerator`
-
-``` purescript
-numerator :: Rational -> Int
-```
-
-#### `denominator`
-
-``` purescript
-denominator :: Rational -> Int
-```
 
 #### `toNumber`
 

--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -1,0 +1,20 @@
+module Data.Ratio where
+
+import Prelude
+
+data Ratio a = Ratio a a
+
+instance semiringRatio :: (Semiring a) => Semiring (Ratio a) where
+  one = Ratio one one
+  mul (Ratio a b) (Ratio c d) = Ratio (a * c) (b * d)
+  zero = Ratio zero one
+  add (Ratio a b) (Ratio c d) = Ratio ((a * d) + (b * c)) (b * d)
+
+instance ringRatio :: (Ring a) => Ring (Ratio a) where
+  sub (Ratio a b) (Ratio c d) = Ratio ((a * d) - (b * c)) (b * d)
+
+numerator :: forall a. Ratio a -> a
+numerator (Ratio a _) = a
+
+denominator :: forall a. Ratio a -> a
+denominator (Ratio _ b) = b

--- a/src/Data/Rational.js
+++ b/src/Data/Rational.js
@@ -1,0 +1,3 @@
+// module Data.Rational
+
+exports.abs = Math.abs;

--- a/src/Data/Rational.purs
+++ b/src/Data/Rational.purs
@@ -1,53 +1,56 @@
 module Data.Rational
-  ( Rational()
+  ( Rational(..)
   , (%)
-  , numerator
-  , denominator
   , toNumber
   , fromInt
   ) where
 
 import Prelude
 import qualified Data.Int as Int
+import Data.Ratio
 
-data Rational = Rational Int Int
+newtype Rational = Rational (Ratio Int)
 
 instance showRational :: Show Rational where
-  show (Rational a b) = "Rational " ++ show a ++ " " ++ show b
-
-instance semiringRational :: Semiring Rational where
-  one = Rational 1 1
-  mul (Rational a b) (Rational c d) = Rational (a * c) (b * d)
-  zero = Rational 0 1
-  add (Rational a b) (Rational c d) = Rational ((a * d) + (b * c)) (b * d)
-
-instance ringRational :: Ring Rational where
-  sub (Rational a b) (Rational c d) = Rational ((a * d) - (b * c)) (b * d)
+  show (Rational (Ratio a b)) = show a ++ " % " ++ show b
 
 instance eqRational :: Eq Rational where
-  eq p q = numerator (reduce p) == numerator (reduce q) && denominator (reduce p) == denominator (reduce q)
+  eq x y = eq' (reduce x) (reduce y)
+    where
+    eq' (Rational (Ratio a' b')) (Rational (Ratio c' d')) = a' == c' && d' == d'
+
+instance semiringRational :: Semiring Rational where
+  one = Rational $ one
+  mul (Rational a) (Rational b) = reduce $ Rational $ a `mul` b
+  zero = Rational $ zero
+  add (Rational a) (Rational b) = reduce $ Rational $ a `add` b
+
+instance ringRational :: Ring Rational where
+  sub (Rational a) (Rational b) = reduce $ Rational $ a `sub` b
 
 infixl 7 %
 
 (%) :: Int -> Int -> Rational
-(%) m n = reduce $ Rational m n
-
-numerator :: Rational -> Int
-numerator (Rational a _) = a
-
-denominator :: Rational -> Int
-denominator (Rational _ b) = b
+(%) x y = reduce $ Rational $ Ratio (x * signum y) (abs y)
+  where
+  signum :: Int -> Int
+  signum 0 = 0
+  signum x | x < 0 = -1
+  signum _ = 1
 
 toNumber :: Rational -> Number
-toNumber (Rational a b) = Int.toNumber a / Int.toNumber b
+toNumber (Rational (Ratio a b)) = Int.toNumber a / Int.toNumber b
 
 fromInt :: Int -> Rational
-fromInt i = Rational i 1
+fromInt i = Rational $ Ratio i 1
 
 reduce :: Rational -> Rational
-reduce (Rational a b) = Rational (a `div` gcd a b) (b `div` gcd a b)
+reduce (Rational (Ratio a b)) = Rational $ Ratio (a / gcd a b) (b / gcd a b)
   where
     gcd :: Int -> Int -> Int
     gcd m n
       | n == 0 = m
       | otherwise = gcd n (m `mod` n)
+
+foreign import abs :: Int -> Int
+


### PR DESCRIPTION
Fixes #3 

Want to take a look at this @paf31?

Btw, it's a little unfortunate that even fairly large numbers will overflow:

```
> (1 % 50000) * (3 % 50000)
1 % -598322432
```

I'm thinking if I should make Rational `Ratio BigInt`.
