### PR TITLE
Use Data.EuclideanRing.gcd from purescript-prelude 2.3.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,11 +13,11 @@
     "output"
   ],
   "dependencies": {
-    "purescript-integers": "^2.0.0"
+    "purescript-integers": "^2.0.0",
+    "purescript-prelude": "^2.3.0"
   },
   "devDependencies": {
     "purescript-console": "^2.0.0",
-    "purescript-prelude": "^2.0.0",
     "purescript-strongcheck": "^2.0.0",
     "purescript-strongcheck-laws": "^1.0.0"
   }

--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -5,27 +5,31 @@ module Data.Ratio
   , gcd
   ) where
 
-import Prelude
+import Prelude ( class CommutativeRing, class Eq, class EuclideanRing
+               , class Field, class Ring, class Semiring
+               , one, zero, (*), (+), (-)
+               )
+import Prelude ( gcd ) as Prelude
 
 data Ratio a = Ratio a a
 
-instance semiringRatio :: (Semiring a) => Semiring (Ratio a) where
+instance semiringRatio :: Semiring a => Semiring (Ratio a) where
   one = Ratio one one
   mul (Ratio a b) (Ratio c d) = Ratio (a * c) (b * d)
   zero = Ratio zero one
   add (Ratio a b) (Ratio c d) = Ratio ((a * d) + (b * c)) (b * d)
 
-instance ringRatio :: (Ring a) => Ring (Ratio a) where
+instance ringRatio :: Ring a => Ring (Ratio a) where
   sub (Ratio a b) (Ratio c d) = Ratio ((a * d) - (b * c)) (b * d)
 
-instance commutativeRingRatio :: (CommutativeRing a) => CommutativeRing (Ratio a)
+instance commutativeRingRatio :: CommutativeRing a => CommutativeRing (Ratio a)
 
 instance euclideanRingRatio :: (CommutativeRing a, Semiring a) => EuclideanRing (Ratio a) where
   degree _ = 1
   div (Ratio a b) (Ratio c d) = Ratio (a * d) (b * c)
   mod _ _ = zero
 
-instance fieldRatio :: (Field a) => Field (Ratio a)
+instance fieldRatio :: Field a => Field (Ratio a)
 
 numerator :: forall a. Ratio a -> a
 numerator (Ratio a _) = a
@@ -34,7 +38,4 @@ denominator :: forall a. Ratio a -> a
 denominator (Ratio _ b) = b
 
 gcd :: forall a. (Eq a, EuclideanRing a) => Ratio a -> a
-gcd (Ratio m n)
-  | n == zero = m
-  | otherwise = gcd (Ratio n (m `mod` n))
-
+gcd (Ratio m n) = Prelude.gcd m n

--- a/src/Data/Rational.purs
+++ b/src/Data/Rational.purs
@@ -9,7 +9,7 @@ module Data.Rational
 import Prelude
 import Data.Int as Int
 import Data.Ord (signum)
-import Data.Ratio (Ratio(Ratio), gcd)
+import Data.Ratio (Ratio(Ratio))
 
 newtype Rational = Rational (Ratio Int)
 
@@ -54,7 +54,7 @@ fromInt :: Int -> Rational
 fromInt i = Rational $ Ratio i 1
 
 reduce :: Rational -> Rational
-reduce (Rational ratio@(Ratio a b)) =
-  let x = a / gcd ratio
-      y = b / gcd ratio
-  in Rational $ Ratio (x * signum y) (degree y)
+reduce (Rational (Ratio a b)) =
+  let g = gcd a b
+      b' = b / g
+  in Rational $ Ratio ((a / g) * signum b') (degree b')


### PR DESCRIPTION
This fixes an import shadowing warning as Data.Rational can as well just use 
Prelude.gcd directly, eliminating the need to import Data.Ratio.gcd.