### PR TITLE
Update for purs 0.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-integers": "^2.0.0",
-    "purescript-prelude": "^2.3.0"
+    "purescript-integers": "^3.0.0",
+    "purescript-prelude": "^3.0.0"
   },
   "devDependencies": {
-    "purescript-console": "^2.0.0",
-    "purescript-strongcheck": "^2.0.0",
-    "purescript-strongcheck-laws": "^1.0.0"
+    "purescript-console": "^3.0.0",
+    "purescript-strongcheck": "^3.0.0",
+    "purescript-strongcheck-laws": "^2.0.0"
   }
 }

--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -37,5 +37,5 @@ numerator (Ratio a _) = a
 denominator :: forall a. Ratio a -> a
 denominator (Ratio _ b) = b
 
-gcd :: forall a. (Eq a, EuclideanRing a) => Ratio a -> a
+gcd :: forall a. Eq a => EuclideanRing a => Ratio a -> a
 gcd (Ratio m n) = Prelude.gcd m n

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -49,7 +49,7 @@ instance arbitraryTestRatNonZero :: Arbitrary TestRatNonZero where
 testRatNonZero :: Proxy TestRatNonZero
 testRatNonZero = Proxy
 
-main :: forall eff. Eff (console :: CONSOLE, random :: RANDOM, err :: EXCEPTION | eff) Unit
+main :: forall eff. Eff (console :: CONSOLE, random :: RANDOM, exception :: EXCEPTION | eff) Unit
 main = checkLaws "Rational" do
   Data.checkEq testRational
   Data.checkOrd testRational


### PR DESCRIPTION
purescript 0.11.1 changed the constraint syntax:

  (Eq a, Org a) => ...

is now written as

  Eq a => Ord a => ...

Also, purescript-exceptions changed the label from 'error' to 'exception'.