### PR TITLE
Showable ratios

### DIFF
--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -8,10 +8,14 @@ module Data.Ratio
 import Prelude ( class CommutativeRing, class Eq, class EuclideanRing
                , class Field, class Ring, class Semiring
                , one, zero, (*), (+), (-)
+               , class Show, show, (<>)
                )
 import Prelude ( gcd ) as Prelude
 
 data Ratio a = Ratio a a
+
+instance showRatio :: Show a => Show (Ratio a) where
+  show (Ratio a b) = "(Ratio " <> show a <> " " <> show b <> ")"
 
 instance semiringRatio :: Semiring a => Semiring (Ratio a) where
   one = Ratio one one


### PR DESCRIPTION
Moved the implementation for the show typeclass from Rational to Ratio, Rationals just call the show method on the wrapped Ratio. 
Ratios are now displayed with the '%' symbol as well as Rationals. If this is not wanted, as % is a constructor for the Rational, but not for the Ratio, I would nevertheless suggest to implement a simple show instance for Ratio.
