### PR TITLE
Export Ratio data constructor

### DIFF
--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -1,5 +1,5 @@
 module Data.Ratio
-  ( Ratio
+  ( Ratio (..)
   , reduce
   , (%)
   , numerator


### PR DESCRIPTION
Since 4.0.0 the `Ratio` data constructor is no longer exported, removing the possibility to pattern match against a Ratio. I would suggest adding at least one possibility to pattern match against a Ratio, as it seems quite natural to me to extract numerator and denominator by pattern matching, eg. in
```
toMixedRatio :: Rational -> {whole :: Int, propper :: Rational}
toMixedRatio (Ratio num den) = {whole, propper}
  where
    -- Calculate whole part of the impropper ratio and substract it to get
    -- propper ratio
    whole   = num / den
    propper = (num - whole * den) % den

```

Besides exporting `Ratio` directly, `(%)` could be made an infix alias for the data constructor, which would allow pattern matching with it as in ```f (num % den) = (f' num) % den```. This would probably a bit more intuitive, as `(%)` could then be used as construction and pattern matching. The problem here is, that `(%)` could no longer be used as an alias for reduce. Perhaps a second operator eg. `(!%)` could be used as alias for reduce.
