### PR TITLE
Update for PureScript 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - 6
+  - stable
 install:
   - npm install bower -g
   - npm install

--- a/bower.json
+++ b/bower.json
@@ -13,12 +13,12 @@
     "output"
   ],
   "dependencies": {
-    "purescript-integers": "^3.0.0",
-    "purescript-prelude": "^3.0.0"
+    "purescript-integers": "^4.0.0",
+    "purescript-prelude": "^4.0.1"
   },
   "devDependencies": {
-    "purescript-console": "^3.0.0",
-    "purescript-strongcheck": "^3.0.0",
-    "purescript-strongcheck-laws": "^2.0.0"
+    "purescript-console": "^4.1.0",
+    "purescript-strongcheck": "^4.0.0",
+    "purescript-strongcheck-laws": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "test": "pulp test"
   },
   "devDependencies": {
-    "pulp": "^11.0.0",
-    "purescript": "^0.11.0"
+    "pulp": "^12.3.0",
+    "purescript": "^0.12.0"
   }
 }

--- a/src/Data/Ratio.purs
+++ b/src/Data/Ratio.purs
@@ -44,7 +44,8 @@ instance euclideanRingRatio :: (Ord a, EuclideanRing a) => EuclideanRing (Ratio 
   div (Ratio a b) (Ratio c d) = reduce (a * d) (b * c)
   mod _ _ = zero
 
-instance fieldRatio :: (Ord a, EuclideanRing a) => Field (Ratio a)
+instance divisionRingRatio :: (Ord a, EuclideanRing a) => DivisionRing (Ratio a) where
+  recip (Ratio a b) = Ratio b a
 
 reduce :: forall a. Ord a => EuclideanRing a => a -> a -> Ratio a
 reduce n d =

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -2,10 +2,8 @@ module Test.Main where
 
 import Prelude
 
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE, log)
-import Control.Monad.Eff.Random (RANDOM)
-import Control.Monad.Eff.Exception (EXCEPTION)
+import Effect (Effect)
+import Effect.Console (log)
 
 import Data.Ratio ((%))
 import Data.Rational (Rational)
@@ -23,10 +21,10 @@ newtype TestRational = TestRational Rational
 derive newtype instance commutativeRingTestRational :: CommutativeRing TestRational
 derive newtype instance eqTestRational :: Eq TestRational
 derive newtype instance euclideanRingTestRational :: EuclideanRing TestRational
-derive newtype instance fieldTestRational :: Field TestRational
 derive newtype instance ordTestRational :: Ord TestRational
 derive newtype instance ringTestRational :: Ring TestRational
 derive newtype instance semiringTestRational :: Semiring TestRational
+derive newtype instance divisionRingTestRational :: DivisionRing TestRational
 
 int :: Gen Int
 int = chooseInt (-999) 999
@@ -35,7 +33,7 @@ nonZeroInt :: Gen Int
 nonZeroInt = int `suchThat` notEq 0
 
 newtype SmallInt = SmallInt Int
-  
+
 instance arbitrarySmallInt :: Arbitrary SmallInt where
   arbitrary = SmallInt <$> int
 
@@ -57,6 +55,7 @@ derive newtype instance semiringTestRatNonZero :: Semiring TestRatNonZero
 derive newtype instance ringTestRatNonZero :: Ring TestRatNonZero
 derive newtype instance commutativeRingTestRatNonZero :: CommutativeRing TestRatNonZero
 derive newtype instance euclideanRingTestRatNonZero :: EuclideanRing TestRatNonZero
+derive newtype instance divisionRingTestRatNonZero :: DivisionRing TestRatNonZero
 
 instance arbitraryTestRatNonZero :: Arbitrary TestRatNonZero where
   arbitrary = compose TestRatNonZero <<< (%) <$> nonZeroInt <*> nonZeroInt
@@ -64,7 +63,7 @@ instance arbitraryTestRatNonZero :: Arbitrary TestRatNonZero where
 testRatNonZero :: Proxy TestRatNonZero
 testRatNonZero = Proxy
 
-main :: forall eff. Eff (console :: CONSOLE, random :: RANDOM, exception :: EXCEPTION | eff) Unit
+main :: Effect Unit
 main = checkLaws "Rational" do
   Data.checkEq testRational
   Data.checkOrd testRational


### PR DESCRIPTION
Now that the new version of the compiler is out, we're updating several of our libraries and applications at CitizenNet to use it. We rely on `purescript-rationals` in many places, so a key part to updating our libraries is to use a compatible version of this library as well.

This pull request bumps all dependencies to their 0.12-compatible versions, makes sure this package is compatible, and verifies all tests run with the new output.

The only thing left is to release a new Git tag!

```sh
pulp version
-> v3.0.0
pulp pubish
```