### PR TITLE
Verify instances of DivisionRing

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
   },
   "devDependencies": {
     "purescript-console": "^4.1.0",
-    "purescript-strongcheck": "^4.0.0",
+    "purescript-strongcheck": "^4.1.0",
     "purescript-strongcheck-laws": "^3.0.0"
   }
 }

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -72,8 +72,10 @@ main = checkLaws "Rational" do
   Data.checkCommutativeRing testRational
   Data.checkField testRational
   Data.checkEuclideanRing testRatNonZero
+  Data.checkDivisionRing testRational
+  Data.checkDivisionRing testRatNonZero
 
-  log "Checking 'Remainder' law for MuduloSemiring"
+  log "Checking 'Remainder' law for ModuloSemiring"
   quickCheck' 1000 remainder
 
   log "Checking `reduce`"


### PR DESCRIPTION
It turns out I wasn't quite correct about not needing to verify the `DivisionRing` laws. I have added checking to the `purescript-strongcheck` and `purescript-strongcheck-laws` repositories:
https://github.com/garyb/purescript-strongcheck-laws/pull/4

Until those pull requests are merged, I have added identical (small) tests directly into this repository inline the same way you did for `ModuleSemiring`. These verify that the non-zero and multiplicative laws are satisfied as detailed here:

https://pursuit.purescript.org/packages/purescript-prelude/4.0.1/docs/Data.DivisionRing#t:DivisionRing

This is purely a testing change, and won't require a major bump.