### PR TITLE
Upgrade dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,12 +14,12 @@
   ],
   "dependencies": {
     "purescript-integers": "^5.0.0",
-    "purescript-prelude": "^5.0.0"
+    "purescript-prelude": "^5.0.1"
   },
   "devDependencies": {
-    "purescript-bigints": "^5.0.0",
+    "purescript-bigints": "^6.0.0",
     "purescript-console": "^5.0.0",
-    "purescript-quickcheck": "^7.0.0",
-    "purescript-quickcheck-laws": "^6.0.0"
+    "purescript-quickcheck": "^7.1.0",
+    "purescript-quickcheck-laws": "^6.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "devDependencies": {
     "pulp": "^15.0.0",
-    "spago": "^0.19.1",
-    "purescript": "^0.14.0",
+    "spago": "^0.20.3",
+    "purescript": "^0.14.3",
     "big-integer": "^1.6.48"
   }
 }

--- a/packages.dhall
+++ b/packages.dhall
@@ -105,6 +105,6 @@ in  upstream
 -------------------------------
 -}
 let upstream =
-      https://github.com/purescript/package-sets/releases/download/psc-0.14.0-20210302/packages.dhall sha256:20cc5b89cf15433623ad6f250f112bf7a6bd82b5972363ecff4abf1febb02c50
+      https://github.com/purescript/package-sets/releases/download/psc-0.14.3-20210722/packages.dhall sha256:1ceb43aa59436bf5601bac45f6f3781c4e1f0e4c2b8458105b018e5ed8c30f8c
 
 in  upstream

--- a/spago.dhall
+++ b/spago.dhall
@@ -3,7 +3,7 @@ Welcome to a Spago project!
 You can edit this file as you like.
 -}
 { name = "rationals"
-, dependencies = [ "integers" ]
+, dependencies = [ "integers", "prelude" ]
 , packages = ./packages.dhall
 , sources = [ "src/**/*.purs" ]
 }

--- a/test.dhall
+++ b/test.dhall
@@ -2,6 +2,13 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [  "bigints", "console", "test-unit", "quickcheck-laws"  ]
+  dependencies = conf.dependencies # 
+    [ "bigints"
+    , "console"
+    , "effect"
+    , "quickcheck"
+    , "test-unit"
+    , "quickcheck-laws"  
+    ]
 }
  


### PR DESCRIPTION
In particular, a release of bigints which should now allow publication,
together with minor releases of other libraries in bower.json.

Also, upgrade devDependencies in package.json, use the latest package-sets and
ensure all dependencies are present in spago.dhall and test.dhall.