### PR TITLE
Fix warnings by removing redundant dependency and imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ New features:
 
 Bugfixes:
 
+- Qualified Data.Int and Data.Ratio imports generate warnings (#44).
+
 Other improvements:
 
 ## v6.0.0

--- a/spago.dhall
+++ b/spago.dhall
@@ -1,5 +1,5 @@
 { name = "rationals"
-, dependencies = [ "integers", "js-bigints", "prelude" ]
+, dependencies = [ "js-bigints", "prelude" ]
 , license = "MIT"
 , repository = "https://github.com/purescript-contrib/purescript-rationals.git"
 , packages = ./packages.dhall

--- a/src/Data/Rational.purs
+++ b/src/Data/Rational.purs
@@ -12,8 +12,6 @@ module Data.Rational
 
 import Prelude
 
-import Data.Int as Int
-import Data.Ratio (Ratio, denominator, numerator, (%))
 import Data.Ratio as Ratio
 import JS.BigInt (BigInt)
 import JS.BigInt as BigInt

--- a/test.dhall
+++ b/test.dhall
@@ -2,6 +2,6 @@ let conf = ./spago.dhall
 
 in conf // {
   sources = conf.sources # [ "test/**/*.purs" ],
-  dependencies = conf.dependencies # [  "console", "effect", "integers", "quickcheck", "quickcheck-laws"  ]
+  dependencies = conf.dependencies # [  "console", "effect", "quickcheck", "quickcheck-laws"  ]
 }
  


### PR DESCRIPTION
Remove redundant qualified Data.Int and Data.Ratio imports as well as the integers dependency. Fixes #44.

**Description of the change**

This fixes warnings printed by spago build.

**Checklist:**

- [x] Added the change to the changelog's "Unreleased" section with a link to this PR and your username
- [x] Linked any existing issues or proposals that this pull request should close
- [ ] Updated or added relevant documentation in the README and/or documentation directory
- [ ] Added a test for the contribution (if applicable)
